### PR TITLE
#11 Embed QR code instead of using external link

### DIFF
--- a/resources/views/email/footer.blade.php
+++ b/resources/views/email/footer.blade.php
@@ -20,7 +20,7 @@
                 <tr>
                   <td class="content-block powered-by">
                     <small>Službu poskytuje Cyklokoalícia. <strong>Ak chcete, aby sme službu prevádzkovali aj naďalej, podporte nás sumou 10+€ na účet: SK9683300000002700175046 (variabilný symbol 0314 alebo poznámka EIA).</strong></small><br/>
-                    <img src="{{ asset('images/eia-bsqr.png') }}" alt="PayBySquare" class="byqr" />
+                    <img src="{{ $message->embed(public_path().'/images/eia-bsqr.png') }}" alt="PayBySquare" class="byqr" />
                   </td>
                 </tr>
               </table>


### PR DESCRIPTION
Based on request from @martinmacko47 
Embed QR code image instead of using external link to support email clients that block external links to prevent email tracking.

> Ako komplikovane by bolo, aby ten obrazok bol rovno sucastou mailu ako priloha pouzita v HTML. Lebo ked je externa linka, tak niektore mailove programy take obrazky nezobrazuju. Aby zabranili zisteniu, ze mail bol otvoreny.

Embeds image correctly as follows:
`<img src=3D"cid:e6f93eb70f5411acea73669caae007c6@swift.=
generated" alt=3D"PayBySquare" class=3D"byqr" />`