### PR TITLE
#14 Add automatic watcher removal after Mailgun permanent failure

### DIFF
--- a/app/Http/Controllers/Webhooks.php
+++ b/app/Http/Controllers/Webhooks.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller as BaseController;
+use Symfony\Component\HttpKernel\Exception\NotAcceptableHttpException;
+use Symfony\Component\Routing\Exception\NoConfigurationException;
+
+class Webhooks extends BaseController
+{
+    private function verifyWebhook($signature, $key)
+    {
+        $hash = \hash_hmac('sha256', $signature['timestamp'] . $signature['token'], $key);
+        return $signature['signature'] === $hash;
+    }
+
+    /**
+     * Handles Permanent Failure event from Mailgun.
+     *
+     * @param Request $request Webhook body
+     * @return string
+     */
+    public function permanentFailure(Request $request)
+    {
+        $key = app('config')->get('services')['mailgun']['signingKey'];
+        if (!$key) {
+            throw new NoConfigurationException();
+        }
+        if (!$this->verifyWebhook($request->signature, $key)) {
+            throw new NotAcceptableHttpException();
+        }
+
+        \App\Watcher::where('email', $request->{'event-data'}['recipient'])->delete();
+        return 'ok';
+    }
+}

--- a/config/services.php
+++ b/config/services.php
@@ -17,6 +17,7 @@ return [
     'mailgun' => [
         'domain' => env('MAILGUN_DOMAIN'),
         'secret' => env('MAILGUN_SECRET'),
+        'signingKey' => env('MAILGUN_SIGNING_KEY'),
     ],
 
     'ses' => [

--- a/routes/api.php
+++ b/routes/api.php
@@ -13,6 +13,4 @@ use Illuminate\Http\Request;
 |
 */
 
-Route::middleware('auth:api')->get('/user', function (Request $request) {
-    return $request->user();
-});
+Route::post('permanent-failure', ['uses' => 'Webhooks@permanentFailure', 'as' => 'permanentFailure']);


### PR DESCRIPTION
Potrebné v `.env` nastaviť `MAILGUN_SIGNING_KEY` (https://app.mailgun.com/app/account/security/api_keys a tam "HTTP webhook signing key" ) 

a do Mailgun pridať Webhook na adresu:
https://eia.cyklokoalicia.sk/api/permanent-failure

<img width="832" alt="image" src="https://user-images.githubusercontent.com/1540458/97802746-f8f41900-1c45-11eb-8337-55c11d167dd8.png">

